### PR TITLE
chore: add .env* to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ dist-deno
 /*.tgz
 .idea/
 .eslintcache
-
+.env*


### PR DESCRIPTION
## Summary
- Add `.env*` pattern to `.gitignore` to prevent accidental commit of files containing `LLAMA_API_KEY` or other secrets
- Defense-in-depth measure — no `.env` files exist today, but this prevents future accidents

## Test plan
- [x] Verify `.gitignore` correctly excludes `.env`, `.env.local`, `.env.production`, etc.
- [x] No existing tracked files affected