### PR TITLE
fix(ci): update examples workflow to Node 20

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
       - name: Install dependencies
         env:
           GITHUB_TOKEN: ${{ secrets.MY_GITHUB_TOKEN }}
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
       - name: Install dependencies
         env:
           GITHUB_TOKEN: ${{ secrets.MY_GITHUB_TOKEN }}
@@ -57,7 +57,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
       - name: Install dependencies
         env:
           GITHUB_TOKEN: ${{ secrets.MY_GITHUB_TOKEN }}
@@ -77,7 +77,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
       - name: Install dependencies
         env:
           GITHUB_TOKEN: ${{ secrets.MY_GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Update all 4 jobs in `.github/workflows/examples.yml` from Node 18 to Node 20
- Aligns with `ci.yml` (already Node 20) and README which states Node 20 LTS as minimum

## Test plan
- [x] Verified examples workflow YAML is valid
- [x] All 4 jobs (chat, structured, tool_call, vision) updated consistently