### PR TITLE
fix(docs): fix typos in generated type docs

### DIFF
--- a/src/resources/chat/chat.ts
+++ b/src/resources/chat/chat.ts
@@ -30,7 +30,7 @@ export interface CompletionMessage {
   /**
    * The reason why we stopped. Options are: - "stop": The model reached a natural
    * stopping point. - "tool_calls": The model finished generating and invoked a tool
-   * call. - "length": The model reached the maxinum number of tokens specified in
+   * call. - "length": The model reached the maximum number of tokens specified in
    * the request.
    */
   stop_reason?: 'stop' | 'tool_calls' | 'length';
@@ -138,7 +138,7 @@ export namespace CreateChatCompletionResponseStreamChunk {
     /**
      * The reason why we stopped. Options are: - "stop": The model reached a natural
      * stopping point. - "tool_calls": The model finished generating and invoked a tool
-     * call. - "length": The model reached the maxinum number of tokens specified in
+     * call. - "length": The model reached the maximum number of tokens specified in
      * the request.
      */
     stop_reason?: 'stop' | 'tool_calls' | 'length';

--- a/src/resources/chat/completions.ts
+++ b/src/resources/chat/completions.ts
@@ -56,7 +56,7 @@ export interface CompletionCreateParamsBase {
   max_completion_tokens?: number;
 
   /**
-   * Controls the likelyhood and generating repetitive responses.
+   * Controls the likelihood of generating repetitive responses.
    */
   repetition_penalty?: number;
 


### PR DESCRIPTION
## Summary
- Fix "likelyhood" → "likelihood" in `repetition_penalty` description (`completions.ts`)
- Fix "maxinum" → "maximum" in `stop_reason` description (`chat.ts`, 2 occurrences)

Note: these originate from the OpenAPI spec — ideally fix upstream too.

## Test plan
- [x] `tsc --noEmit` passes
- [x] Full test suite passes (277 tests)