### PR TITLE
chore: tighten files field and remove empty FAQ section

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,8 +385,6 @@ const client = new LlamaAPIClient({
 });
 ```
 
-## Frequently Asked Questions
-
 ## Semantic versioning
 
 This package generally follows [SemVer](https://semver.org/spec/v2.0.0.html) conventions, though certain backwards-incompatible changes may be released as minor versions:

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "packageManager": "yarn@1.22.22",
   "files": [
-    "**/*"
+    "dist"
   ],
   "private": false,
   "publishConfig": {


### PR DESCRIPTION
## Summary
- Change `"files": ["**/*"]` to `["dist"]` in package.json to prevent including tests, scripts, and CI configs when running `npm pack` from root
- Remove empty "Frequently Asked Questions" heading from README that had no content

## Test plan
- [x] `npm pack --dry-run` from root now only includes dist files
- [x] README renders correctly without the empty section