### PR TITLE
docs(examples): fix tool_call types and add missing examples

### DIFF
--- a/examples/error_handling.ts
+++ b/examples/error_handling.ts
@@ -1,0 +1,40 @@
+#!/usr/bin/env -S npm run tsn -T
+
+import LlamaAPIClient, {
+  APIError,
+  AuthenticationError,
+  RateLimitError,
+  NotFoundError,
+  APIConnectionError,
+} from 'llama-api-client';
+
+const client = new LlamaAPIClient();
+
+async function main() {
+  try {
+    const response = await client.chat.completions.create({
+      model: 'Llama-3.3-70B-Instruct',
+      messages: [{ role: 'user', content: 'Hello!' }],
+    });
+    console.log(response.completion_message.content);
+  } catch (err) {
+    if (err instanceof AuthenticationError) {
+      console.error('Authentication failed — check your LLAMA_API_KEY');
+      console.error(`Status: ${err.status}`);
+    } else if (err instanceof RateLimitError) {
+      console.error('Rate limited — try again later');
+      console.error(`Status: ${err.status}`);
+    } else if (err instanceof NotFoundError) {
+      console.error('Resource not found');
+      console.error(`Status: ${err.status}`);
+    } else if (err instanceof APIConnectionError) {
+      console.error('Connection failed — check your network');
+    } else if (err instanceof APIError) {
+      console.error(`API error: ${err.status} — ${err.message}`);
+    } else {
+      throw err;
+    }
+  }
+}
+
+main();

--- a/examples/models.ts
+++ b/examples/models.ts
@@ -1,0 +1,24 @@
+#!/usr/bin/env -S npm run tsn -T
+
+import LlamaAPIClient from 'llama-api-client';
+
+const client = new LlamaAPIClient();
+
+async function main() {
+  // List all available models
+  const models = await client.models.list();
+  console.log('Available models:');
+  for (const model of models) {
+    console.log(`  - ${model.id} (owned by: ${model.owned_by})`);
+  }
+
+  // Retrieve a specific model
+  const model = await client.models.retrieve('Llama-3.3-70B-Instruct');
+  console.log(`\nModel details:`);
+  console.log(`  ID: ${model.id}`);
+  console.log(`  Object: ${model.object}`);
+  console.log(`  Owned by: ${model.owned_by}`);
+  console.log(`  Created: ${model.created}`);
+}
+
+main();

--- a/examples/moderations.ts
+++ b/examples/moderations.ts
@@ -1,0 +1,21 @@
+#!/usr/bin/env -S npm run tsn -T
+
+import LlamaAPIClient from 'llama-api-client';
+
+const client = new LlamaAPIClient();
+
+async function main() {
+  const response = await client.moderations.create({
+    messages: [{ role: 'user', content: 'Hello, how are you today?' }],
+  });
+
+  console.log('Moderation results:');
+  for (const result of response.results) {
+    console.log(`  Flagged: ${result.flagged}`);
+    if (result.flagged_categories.length > 0) {
+      console.log(`  Categories: ${result.flagged_categories.join(', ')}`);
+    }
+  }
+}
+
+main();

--- a/examples/tool_call.ts
+++ b/examples/tool_call.ts
@@ -53,7 +53,10 @@ async function run_streaming(): Promise<void> {
   });
 
   let stopReason: string = 'stop';
-  let toolCall: any = { function: { arguments: '' } };
+  let toolCall: { id: string; function: { name: string; arguments: string } } = {
+    id: '',
+    function: { name: '', arguments: '' },
+  };
 
   for await (const chunk of response) {
     if (chunk.event.delta.type === 'tool_call' && chunk.event.delta.id) {


### PR DESCRIPTION
## Summary
- Fix `any` type in `tool_call.ts` streaming variant with a proper typed object literal
- Add `examples/error_handling.ts` — catching specific API error types
- Add `examples/models.ts` — listing and retrieving models
- Add `examples/moderations.ts` — content moderation API

## Test plan
- [x] `tsc --noEmit` — all examples type-check cleanly
- [x] Examples follow existing patterns (shebang, async main, package imports)