### PR TITLE
fix(ci): skip examples workflow for Dependabot and fork PRs

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -12,12 +12,13 @@ on:
 jobs:
   chat:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'pull_request' || (github.actor != 'dependabot[bot]' && !github.event.pull_request.head.repo.fork) }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
       - name: Install dependencies
         env:
           GITHUB_TOKEN: ${{ secrets.MY_GITHUB_TOKEN }}
@@ -32,12 +33,13 @@ jobs:
 
   structured:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'pull_request' || (github.actor != 'dependabot[bot]' && !github.event.pull_request.head.repo.fork) }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
       - name: Install dependencies
         env:
           GITHUB_TOKEN: ${{ secrets.MY_GITHUB_TOKEN }}
@@ -52,12 +54,13 @@ jobs:
 
   tool_call:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'pull_request' || (github.actor != 'dependabot[bot]' && !github.event.pull_request.head.repo.fork) }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
       - name: Install dependencies
         env:
           GITHUB_TOKEN: ${{ secrets.MY_GITHUB_TOKEN }}
@@ -72,12 +75,13 @@ jobs:
 
   vision:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'pull_request' || (github.actor != 'dependabot[bot]' && !github.event.pull_request.head.repo.fork) }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
       - name: Install dependencies
         env:
           GITHUB_TOKEN: ${{ secrets.MY_GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Add `if` condition to all 4 example jobs to skip when the PR is from Dependabot or a fork (these contexts don't have access to the `LLAMA_API_KEY` secret, causing 401 failures)
- Examples still run on: push to main, scheduled hourly runs, and manual dispatch
- Also updates Node 18 → 20 to match `ci.yml` and README

Fixes failing checks on #31 and #32.

## Test plan
- [x] Dependabot PRs (#31, #32) will skip example jobs instead of failing with 401
- [x] Push to main / schedule / manual dispatch still runs examples normally
- [x] The `if` condition `github.actor != 'dependabot[bot]' && !github.event.pull_request.head.repo.fork` is the standard GitHub pattern for this